### PR TITLE
Add PEP 563 support (from __future__ import annotations)

### DIFF
--- a/rplugin/python3/semshi/node.py
+++ b/rplugin/python3/semshi/node.py
@@ -54,13 +54,15 @@ class Node:
             try:
                 self.symbol = self.env[-1].lookup(self.symname)
             except KeyError:
-                # Set dummy hl group, so all fields in __repr__ are defined.
-                self.hl_group = '?'
-                raise Exception('%s can\'t lookup "%s"' % (self, self.symname))
-        if hl_group is not None:
-            self.hl_group = hl_group
-        else:
-            self.hl_group = self._make_hl_group()
+                self.symbol = None
+                if self.symname in builtins:
+                    hl_group = BUILTIN
+                else:
+                    # Set dummy hlgroup, so all fields in __repr__ are defined.
+                    hl_group = None
+        if not hl_group:
+            hl_group = self._make_hl_group()
+        self.hl_group = hl_group
         self.update_tup()
 
     def update_tup(self):
@@ -91,6 +93,12 @@ class Node:
         """Return highlight group the node belongs to."""
         sym = self.symbol
         name = self.name
+
+        if sym is None:
+            # With PEP-563 (postponed annotations), symtable does not
+            # return a symbol for an unresolved node.
+            return UNRESOLVED
+
         if sym.is_parameter():
             table = self.env[-1]
             # We have seen the node, so remove from unused parameters
@@ -164,10 +172,13 @@ class Node:
         """
         if self.hl_group == ATTRIBUTE:
             return self.env[-1]
-        if self.symbol.is_global():
-            return self.env[0]
-        if self.symbol.is_local() and not self.symbol.is_free():
-            return self.env[-1]
+
+        if self.symbol:
+            if self.symbol.is_global():
+                return self.env[0]
+            if self.symbol.is_local() and not self.symbol.is_free():
+                return self.env[-1]
+
         for table in reversed(self.env):
             # Class scopes don't extend to enclosed scopes
             if table.get_type() == 'class':

--- a/test/data/pep-0563-annotations.py
+++ b/test/data/pep-0563-annotations.py
@@ -1,0 +1,35 @@
+# See https://peps.python.org/pep-0563/
+
+class C:
+
+    class D:
+        field2 = 'd_field'
+        def method(self) -> C.D.field2:  # this is OK
+            ...
+
+        def method(self) -> D.field2:  # this FAILS, class D is local to C
+            ...                        # and is therefore only available
+                                       # as C.D. This was already true
+                                       # before the PEP.
+
+        def method(self) -> field2:  # this is OK
+            ...
+
+        def method(self) -> field:  # this FAILS, field is local to C and
+            ...                     # is therefore not visible to D unless
+                                    # accessed as C.field. This was already
+                                    # true before the PEP.
+
+    field = 'c_field'
+    def method(self) -> C.field:  # this is OK
+        ...
+
+    def method(self) -> field:  # this is OK
+        ...
+
+    def method(self) -> C.D:  # this is OK
+        ...
+        a = C.D
+
+    def method(self) -> D:  # this is OK
+        ...

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -827,6 +827,27 @@ def test_posonlyargs_with_annotation():
     assert [n.hl_group for n in names] == [MODULE_FUNC, UNRESOLVED, PARAMETER_UNUSED]
 
 
+@pytest.mark.skipif('sys.version_info < (3, 8)')
+def test_postponed_evaluation_of_annotations_pep563():
+    """Tests parsers with __future__ import annotations (PEP 563)."""
+    # see https://peps.python.org/pep-0563/
+    # see https://github.com/numirias/semshi/issues/116
+    names = parse('\n'.join([
+        'from __future__ import annotations',
+        'from typing import List, Any',
+        'a: int = 1',  # builtins
+        'b: UnknownSymbol = 2',  # non-builtins
+        'c: List[Any] = []',  # imported
+    ]))
+    assert [(n.name, n.hl_group) for n in names] == [
+        ('annotations', IMPORTED),
+        ('List', IMPORTED), ('Any', IMPORTED),
+        ('a', GLOBAL), ('int', BUILTIN),
+        ('b', GLOBAL), ('UnknownSymbol', UNRESOLVED),
+        ('c', GLOBAL), ('List', IMPORTED), ('Any', IMPORTED),
+    ]
+
+
 class TestNode:
 
     def test_node(self):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -870,6 +870,37 @@ def test_postponed_evaluation_of_annotations_pep563(enable_pep563):
     assert [(n.name, n.hl_group) for n in names] == expected
 
 
+@pytest.mark.skipif('sys.version_info < (3, 8)')
+def test_postponed_evaluation_of_annotations_pep563_resolution(request):
+    """Additional tests for PEP 563. The code is from the PEP-563 document."""
+    path = Path(request.fspath.dirname) / 'data/pep-0563-annotations.py'
+    with open(str(path)) as f:
+        names = parse(f.read())
+
+    # print('\n' + '\n'.join(repr(n) for n in names))
+
+    # Tests the eight type annotations on method.
+    def _find_annotations_for_method():
+        for i, _ in enumerate(names):
+            if names[i].name == 'method':
+                yield names[i + 1]
+
+    annos = list(_find_annotations_for_method())
+    # print('\n' + '\n'.join(repr(n) for n in annos))
+
+    assert len(annos) == 8
+
+    assert annos[0].name == 'C' and annos[0].hl_group == GLOBAL
+    assert annos[1].name == 'D' and annos[1].hl_group == UNRESOLVED
+    assert annos[2].name == 'field2' and annos[2].hl_group == LOCAL
+    assert annos[3].name == 'field' and annos[3].hl_group == UNRESOLVED
+
+    assert annos[4].name == 'C' and annos[4].hl_group == GLOBAL
+    assert annos[5].name == 'field' and annos[5].hl_group == LOCAL
+    assert annos[6].name == 'C' and annos[6].hl_group == GLOBAL
+    assert annos[7].name == 'D' and annos[7].hl_group == LOCAL
+
+
 class TestNode:
 
     def test_node(self):


### PR DESCRIPTION
See numirias/semshi#116

[PEP 563 - Postponed Evaluation of Annotations](https://peps.python.org/pep-0563/) is available since python 3.7, but Semshi would throw an error when this behavior is enabled. The main point of PEP-563 is to resolve type hints at runtime; the python symbol table may not return a symbol for annotations.

## Test code

See `test_postponed_evaluation_of_annotations_pep563` in `test_parser.py`:

```python
from __future__ import annotations
from typing import List, Any

# globals
a: int = 1
b: UnknownSymbol = 2
c: List[Any] = []

# nested scope and symbol: a tricker case
def foo():
   local_var: List[Any] = []  # local variables

class Foo:
   attr: List[Any] = ()  # class attributes
   def __init__(self, v: Optional[List[Any]]):  
       temp: Any = None                      
```
