### PR TITLE
feat: display current syntax error in :Semshi status output

### DIFF
--- a/rplugin/python3/semshi/handler.py
+++ b/rplugin/python3/semshi/handler.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from collections import defaultdict
 import threading
 import time
@@ -244,6 +246,11 @@ class BufferHandler:
             offset + 1,
             ERROR_HL_ID,
         )
+
+    @property
+    def syntax_error(self) -> Optional[SyntaxError]:
+        """Get the current syntax error as string."""
+        return self._parser.syntax_errors[-1]
 
     def _place_sign(self, id, line, name):
         self._wrap_async(self._vim.command)(

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -83,7 +83,7 @@ def test_fixable_syntax_errors3():
     """Improved syntax fixing should be able to handle a bad symbol at the
     end of the erroneous line."""
     parser = make_parser('def foo(): x=1-')
-    print(parser.syntax_error.offset)
+    print(parser.syntax_errors[-1].offset)
     assert [n.hl_group for n in parser._nodes] == [LOCAL, LOCAL]
     print(parser._nodes)
     raise NotImplementedError()

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -123,6 +123,21 @@ def test_highlights():
     raise NotImplementedError() # TODO
 
 
+def test_status(vim, tmp_path):
+    """:Semshi status should report a syntax error."""
+    vim.command('edit %s' % (tmp_path / 'foo.py'))
+    vim.current.buffer[:] = ['def():']
+    time.sleep(SLEEP)
+
+    status = vim.command_output('Semshi status')
+    print("\n", status)
+    lines = status.split('\n')
+    assert lines[0] == 'Semshi is attached on (bufnr=1)'
+    assert lines[1] == '- current handler: <BufferHandler(1)>'
+    assert lines[2] == '- handlers: {1: <BufferHandler(1)>}'
+    assert 'invalid syntax' in lines[3]
+
+
 def test_switch_handler(vim, tmp_path):
     """When switching to a different buffer, the current handlers is updated"""
     node_names = lambda: vim.host_eval('[n.name for n in plugin._cur_handler._parser._nodes]')

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -5,6 +5,9 @@ import pynvim
 import pynvim.api
 import pytest
 
+# pylint: disable=consider-using-f-string
+# pylint: disable=unnecessary-lambda-assignment
+
 
 VIMRC = 'test/data/test.vimrc'
 SLEEP = 0.1
@@ -68,7 +71,8 @@ def start_vim(tmp_path):
     def f(argv=None, file=None):
         if argv is None:
             argv = []
-        argv = ['nvim', '-u', VIMRC, '--embed', '--headless', *argv]
+        argv = ['nvim', '-i', 'NONE', '--embed', '--headless',
+                '-u', VIMRC, *argv]
         vim = pynvim.attach('child', argv=argv)
         if file is not None:
             fn = file or (tmp_path / 'foo.py')


### PR DESCRIPTION
feat: :Semshi defaults to :Semshi status on python files.

feat: display current syntax error in :Semshi status output
e.g.

```
Semshi is attached on (bufnr=40)
- current handler: <BufferHandler(40)>
- handlers: {40: <BufferHandler(40)>}
- syntax error: unmatched ']' (<unknown>, line 4)
```