### PR TITLE
feat: add type statement support (PEP-695, Python 3.12 and 3.13)

### DIFF
--- a/rplugin/python3/semshi/visitor.py
+++ b/rplugin/python3/semshi/visitor.py
@@ -416,9 +416,11 @@ class Visitor:
         # Visit alias name in the outer scope
         self.visit(node.name)
 
-        # The type statement has two variable scopes: one for typevar,
+        # The type statement has two variable scopes: one for typevar (if any),
         # and another one (a child scope) for the rhs
-        with self._enter_scope():
+        maybe_scope = (self._enter_scope() if node.type_params \
+                       else contextlib.nullcontext())
+        with maybe_scope:
             for p in node.type_params:
                 self.visit(p)
             with self._enter_scope():

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1055,6 +1055,7 @@ def test_type_statement_py312():
     # https://peps.python.org/pep-0695/
     names = parse('''
         #!/usr/bin/env python3
+        type IntList = list[int]  # non-generic case
         type MyList[T] = list[T]
         #           ^typevar  ^ a resolved reference (treated like a closure)
 
@@ -1067,7 +1068,9 @@ def test_type_statement_py312():
             assert len(mylist) == 3
     ''')
     expected = [
-        # type statement
+        # non-generic type statement
+        *[('IntList', GLOBAL), ('list', BUILTIN), ('int', BUILTIN)],
+        # generic type statement
         *[('MyList', GLOBAL), ('T', LOCAL), ('list', BUILTIN), ('T', FREE)],
         # class A:
         ('A', GLOBAL),


### PR DESCRIPTION
Overview

- [x] Basic `type` statement support (3.12), any following code should not lose their [variable scope](https://peps.python.org/pep-0695/#type-parameter-scopes)
- [x] bound and default parameter support (3.13)
- [x] The new generic syntax, e.g. `class Generic[T]`, `def generic_method[T]`, `def func[T](...)`, etc. (3.12)

References:

- https://docs.python.org/3/library/typing.html#type-aliases
- https://peps.python.org/pep-0695/

Example 1:

```python
type MyList[T] = list[T]

def foo():
   mylist: MyList[int] = [1, 2, 3]   # semshi used to break here
```

Example 2: bound and default (python 3.13):

```python
type Alias1[T, P] = list[P] | set[T]
type Alias2[T, P: type[T]] = list[P] | set[T]
type Alias3[T, P = T] = list[P] | set[T]
type Alias4[T: int, P: int = bool | T] = list[P] | set[T]
```

Example 3: generic syntax

```python
def get_first[T: float](data: list[T]) -> T:
   ...

class Foo[**P, R]:
    fn: Callable[P, R]
    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
        ...
```